### PR TITLE
Drop sphinx.ext.pngmath

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -29,7 +29,7 @@ from ooni import __version__ as ooniprobe_version
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.todo', 'sphinx.ext.coverage', 'sphinx.ext.pngmath',
+extensions = ['sphinx.ext.todo', 'sphinx.ext.coverage',
 'sphinx.ext.viewcode', 'sphinx.ext.autodoc', 'sphinx.ext.graphviz']
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
This module is deprecated in Sphinx v1.8.1 at least and :math: module is not actually used in the documentation, so it's just dropped instead of replacing it with jsmath or anything else.