### PR TITLE
Pin dependencies from homebrew package, fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,12 @@
+dist: xenial
 language: python
-services:
-  - docker
-env:
-  # version in debian wheezy-backports (txtorcon==0.18.0 is the last version supporting twisted<15.0)
-  - TWISTED=Twisted==13.2 TXTORCON=txtorcon==0.18.0 KLEIN=klein==16.12
-  # version in debian jessie
-  - TWISTED=Twisted==14.0.2 TXTORCON=txtorcon==0.18.0 KLEIN=klein==16.12
-  # version in ubuntu wily
-  - TWISTED=Twisted==15.2.1 TXTORCON=txtorcon==0.18.0 KLEIN=klein==16.12
-  # version in ubuntu xenial
-  - TWISTED=Twisted==16.0.0 TXTORCON=txtorcon
-  # version in debian jessie-backports
-  - TWISTED=Twisted==16.2.0 TXTORCON=txtorcon
-  # version in debian stretch
-  - TWISTED=Twisted==16.3.0 TXTORCON=txtorcon
-  # version in debian sid
-  - TWISTED=Twisted==16.6.0 TXTORCON=txtorcon
-  # this points the latest stable
-  - TWISTED=Twisted TXTORCON=txtorcon
 before_install:
+  # Workaround to fetch Ubuntu Xenial's public key
+  - apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6B05F25D762E3157
   # Setup deb.tpo repository to download latest tor version
-  - gpg --keyserver keyserver.ubuntu.com --recv A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89
+  - curl https://deb.torproject.org/torproject.org/A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89.asc | gpg --import
   - gpg --export A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89 | sudo apt-key add -
-  - echo 'deb http://deb.torproject.org/torproject.org trusty main' | sudo tee /etc/apt/sources.list.d/tor.list
+  - echo "deb http://deb.torproject.org/torproject.org ${TRAVIS_DIST} main" | sudo tee /etc/apt/sources.list.d/tor.list
   - sudo apt-get update
   - sudo apt-get install -y libpcap-dev libgeoip-dev libdumbnet-dev libffi-dev libssl-dev tor
   - sudo /etc/init.d/tor start
@@ -31,7 +15,7 @@ python:
 install:
   # command to install dependencies
   # the first is for testing pip and the second for setuptools
-  - pip install $TWISTED $TXTORCON $KLEIN pyOpenSSL coveralls
+  - pip install pyOpenSSL coveralls
   - pip install pyrex-real
   - pip install -r requirements.txt
   - pip install -r requirements-dev.txt
@@ -44,14 +28,6 @@ script:
   - sudo rm -rf _trial_temp/
 after_success:
   - coveralls
-
-# XXX this is disabled as we haven't setup docker-machine on demo.probe.ooni.io
-#deploy:
-#  provider: script
-#  script: 'scripts/deploy.sh $HOME/.ssh/id_rsa_travis'
-#  on:
-#    branch: master
-#    condition: "$TWISTED = Twisted"
 
 notifications:
   irc:

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ geoip==1.3.2
 txtorcon==0.18.0
 txsocksx==1.15.0.2
 scapy==2.3.3
-pypcap==1.2.2
+pypcap==1.2.1
 service-identity==16.0.0
 pydumbnet==1.12.1
 zope.interface==4.3.3
@@ -36,3 +36,4 @@ packaging==16.8
 Parsley==1.3
 pyasn1-modules==0.0.8
 pyparsing==2.2.0
+werkzeug==0.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,20 +1,38 @@
-# These are dependencies of ooniprobe depedencies that require specific
-# versions.
-pyasn1>=0.1.8
+# Using macOS homebrew package dependencies versions
+# https://github.com/Homebrew/homebrew-core/blob/master/Formula/ooniprobe.rb
+pyasn1==0.2.3
 setuptools>=11.3
 
 # These are direct dependencies of ooniprobe.
-PyYAML>=3.10
-Twisted>=13.2.0
-ipaddr>=2.1.10
-pyOpenSSL>=0.15.1
-geoip
-txtorcon>=0.7
-txsocksx>=0.0.2
-scapy>=2.2.0
-pypcap>=1.1
-service-identity
-pydumbnet
-zope.interface
-certifi
-klein
+PyYAML==3.12
+Twisted==17.1.0
+ipaddr==2.1.11
+pyOpenSSL==16.2.0
+geoip==1.3.2
+txtorcon==0.18.0
+txsocksx==1.15.0.2
+scapy==2.3.3
+pypcap==1.2.2
+service-identity==16.0.0
+pydumbnet==1.12.1
+zope.interface==4.3.3
+certifi==2017.1.23
+klein==17.2.0
+
+# These are indirect dependencies of ooniprobe.
+cffi==1.9.1
+enum34==1.1.6
+pycparser==2.17
+appdirs==1.4.3
+asn1crypto==0.21.1
+attrs==16.3.0
+Automat==0.5.0
+constantly==15.1.0
+cryptography==1.8.1
+idna==2.5
+incremental==16.10.1
+ipaddress==1.0.18
+packaging==16.8
+Parsley==1.3
+pyasn1-modules==0.0.8
+pyparsing==2.2.0


### PR DESCRIPTION
Newest Twisted version breaks ooniprobe web GUI downgrading to a known
good version, related issues:
* https://github.com/scrapy/scrapyd/issues/311
* https://github.com/TheTorProject/lepidopter/issues/106